### PR TITLE
fix(preprocess): honor expected_channels=None as 'do-not-pad' sentinel

### DIFF
--- a/src/nahual/preprocess.py
+++ b/src/nahual/preprocess.py
@@ -43,6 +43,10 @@ def pad_channel_dim(pixels: numpy.ndarray, expected_channels: int) -> numpy.ndar
     if pixels.ndim > 2:
         pixels = pixels[:, :, 0]
 
+    # None signals "no padding constraint" (e.g. channel-agnostic models).
+    if expected_channels is None:
+        return pixels
+
     input_channels = pixels.shape[1]
     to_pad = expected_channels - input_channels
 


### PR DESCRIPTION
## Summary

`pad_channel_dim` currently assumes `expected_channels` is always an int and computes `expected_channels - input_channels`, which crashes when a channel-agnostic model registers `None` as its channel guardrail (e.g. the OpenPhenom server in `nahual_vit`, which now uses `(None, 16)` to opt out of zero-padding).

This PR adds an early-return when `expected_channels is None`: skip padding, return the array as-is (after the z-stack slice). Behavior for the int case is unchanged.

## Test plan
- [x] OpenPhenom server in nahual_vit launches and runs end-to-end with `(None, 16)` guardrail
- [x] MorphEm + DINOv2 + SubCell servers (which all use int guardrails) unchanged in behavior — verified via 66-plate re-extraction